### PR TITLE
fix!: correct issue-label matching to exact label, not substrings

### DIFF
--- a/.github/workflows/auto-milestone-wishlist.yaml
+++ b/.github/workflows/auto-milestone-wishlist.yaml
@@ -15,6 +15,10 @@ permissions:
 jobs:
   assign-to-wishlist:
     runs-on: ubuntu-latest
+    # The `if:` gates on the label for `issues` events purely as an efficiency guard
+    # (skip spinning up a runner for non-enhancement issues). For workflow_dispatch it
+    # lets any issue through, and the action's own `issue-label: enhancement` filter
+    # (below) is what actually enforces the label. The two are intentionally layered.
     if: github.event_name == 'workflow_dispatch' || contains(github.event.issue.labels.*.name, 'enhancement')
     steps:
       - name: Checkout code
@@ -49,4 +53,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event_name == 'workflow_dispatch' && inputs.issue-number || github.event.issue.number }}
           target-milestone: "Wishlist"
-          issue-label: "enhancement"
+          issue-label: "enhancement"  # authoritative label filter (esp. for workflow_dispatch)

--- a/.github/workflows/quality-checks.yaml
+++ b/.github/workflows/quality-checks.yaml
@@ -34,7 +34,8 @@ jobs:
       - name: Run shellcheck
         run: |
           echo "::group::Running shellcheck"
-          shellcheck --enable=all ./*.sh
+          # Top-level scripts plus the test harness and its gh mock (no .sh extension).
+          shellcheck --enable=all ./*.sh tests/*.sh tests/bin/*
           echo "::endgroup::"
       - name: Run actionlint
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,9 @@
-# For JavaScript action (if keeping both versions)
-node_modules/
-dist/
-
 # Development files
 *.log
 .env
 .DS_Store
 .vscode/settings.json
 
-# Test coverage
-coverage/
+# Agent / local tooling files
+.claude/
+tasks/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,6 +1,0 @@
-# MD041/first-line-heading : First line heading : https://github.com/DavidAnson/markdownlint/blob/v0.39.0/doc/md041.md
-"MD041": false
-
-# MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.39.0/doc/md013.md
-MD013:
-  line_length: 180

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,9 @@ Add support for multiple milestone targets
 ./tests/test-composite.sh
 ```
 
+This suite runs the real `assign-milestone.sh` end-to-end against a mocked `gh` CLI
+(`tests/bin/gh`) with fixture API responses, so it needs no network access or token.
+
 ### Local Testing with Real Data
 
 ```bash
@@ -164,7 +167,9 @@ This project uses [Release Please](https://github.com/googleapis/release-please)
 
 - **`action.yml`** - Action definition and inputs/outputs
 - **`assign-milestone.sh`** - Main logic for milestone assignment
-- **`tests/test-composite.sh`** - Unit tests
+- **`tests/test-composite.sh`** - End-to-end tests; run the real script offline against a mocked `gh`
+- **`tests/bin/gh`** - Mocked `gh` CLI (shadowed onto `PATH`) so tests need no network or token
+- **`tests/fixtures/`** - Sample GitHub API responses (issues, milestones) used by the tests
 - **`test-local.sh`** - Local testing with real GitHub API
 
 ## Development Guidelines

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test-interactive:
 quality-check:
 	@echo "Running quality checks..."
 	@echo "Running shellcheck..."
-	shellcheck --enable=all *.sh
+	shellcheck --enable=all *.sh tests/*.sh tests/bin/*
 	@echo "Running actionlint..."
 	actionlint
 	@echo "Running ratchet lint..."

--- a/README.md
+++ b/README.md
@@ -2,31 +2,61 @@
 
 # Issue Milestoner
 
-A GitHub Action that automatically assigns issues to milestones based on specified criteria.
+A GitHub Action that automatically assigns issues to a milestone, gated by GitHub
+**issue type** or **label**. It's most useful for organization repositories using
+GitHub issue types, and for sharing one milestone-automation step across many
+repositories with a consistent, versioned contract.
+
+## Do you even need this?
+
+For a single repository doing simple label-based assignment, maybe not — native
+workflow gating plus two lines of `gh` cover it:
+
+```yaml
+- name: Assign to milestone if unset
+  if: contains(github.event.issue.labels.*.name, 'enhancement')
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    n=${{ github.event.issue.number }}
+    has=$(gh issue view "$n" --json milestone --jq '.milestone.title // ""')
+    [ -z "$has" ] && gh issue edit "$n" --milestone "Wishlist"
+```
+
+This action earns its keep when you want:
+
+- **Issue-type gating** (`issue-type`) — GitHub issue types aren't cleanly
+  expressible in workflow `if:` conditions, so this is the awkward case to do by hand.
+- **One reusable, versioned step** shared across many repositories, with consistent
+  outputs (`assigned` / `milestone` / `reason`) and built-in API retries.
+
+If neither applies, the inline snippet above is simpler to own and debug.
 
 ## Features
 
-- ✅ Assigns issues to target milestones
-- ✅ Prevents reassignment if issue already has a milestone
-- ✅ Optional issue type filtering using GitHub issue types ([only available for org-based repos](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-types-in-an-organization))
-- ✅ Optional label filtering using issue labels
+- ✅ Assigns issues to a target milestone (resolved case-insensitively)
+- ✅ Prevents reassignment if the issue already has a milestone
+- ✅ Optional issue-type filtering using GitHub issue types ([only available for org-based repos](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-types-in-an-organization))
+- ✅ Optional label filtering (exact label match, case-insensitive)
 - ✅ Comprehensive logging and error handling
 - ✅ Configurable for any repository
 
+## Migrating from v1
+
+- **Breaking — `issue-label` now matches the exact label** (case-insensitive), not a
+  substring. In v1, `issue-label: ui` also matched a label like `build`, and `bug`
+  matched `debugging`, which could assign milestones unexpectedly. Set `issue-label`
+  to the exact label name; if you relied on partial matching across several labels,
+  use one action step per label.
+- **Improved (non-breaking) — `target-milestone` resolves case-insensitively** against
+  your repository's real milestones (e.g. `wishlist` finds `Wishlist`), as documented.
+
 ## Usage
 
-### Basic Usage
+### Filter by issue type (the primary use case)
 
-```yaml
-- name: Assign Issue to Milestone
-  uses: davidizzy/issue-milestoner@v1.1.3 # x-release-please-version
-  with:
-    github-token: ${{ secrets.GITHUB_TOKEN }}
-    issue-number: ${{ github.event.issue.number }}
-    target-milestone: "my-important-milestone"
-```
-
-### Advanced Usage with Issue Type Filter
+GitHub issue types are awkward to gate on in a workflow `if:` condition — this is
+where the action is most worthwhile. Only assigns issues whose type matches:
 
 ```yaml
 - name: Assign Bug Issues to Milestone
@@ -35,19 +65,34 @@ A GitHub Action that automatically assigns issues to milestones based on specifi
     github-token: ${{ secrets.GITHUB_TOKEN }}
     issue-number: ${{ github.event.issue.number }}
     target-milestone: "my-important-milestone"
-    issue-type: "bug"  # GitHub issue type
+    issue-type: "bug"  # GitHub issue type (org repos only)
 ```
 
-### Advanced Usage with Label Filter
+### Filter by label
+
+Only assigns issues carrying the exact label (case-insensitive):
 
 ```yaml
-- name: Assign Enhancement Issues to Milestone  
+- name: Assign Enhancement Issues to Milestone
   uses: davidizzy/issue-milestoner@v1.1.3 # x-release-please-version
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     issue-number: ${{ github.event.issue.number }}
     target-milestone: "my-important-milestone"
-    issue-label: "enhancement"  # Issue label
+    issue-label: "enhancement"  # exact label match
+```
+
+### No filter
+
+Assigns the milestone to any issue that doesn't already have one:
+
+```yaml
+- name: Assign Issue to Milestone
+  uses: davidizzy/issue-milestoner@v1.1.3 # x-release-please-version
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    issue-number: ${{ github.event.issue.number }}
+    target-milestone: "my-important-milestone"
 ```
 
 ### Workflow Example
@@ -84,7 +129,7 @@ jobs:
 | `issue-number` | Issue number to process | Yes | - |
 | `target-milestone` | Target milestone to assign to the issue | Yes | - |
 | `issue-type` | Optional GitHub issue type filter (e.g., bug, feature, task) | No | - |
-| `issue-label` | Optional issue label filter (e.g., enhancement, documentation, ui) | No | - |
+| `issue-label` | Optional exact label filter, case-insensitive (e.g., enhancement, documentation) | No | - |
 | `repository` | Repository in the format owner/repo | No | Current repository |
 
 ## Outputs
@@ -98,9 +143,9 @@ jobs:
 ## Behavior
 
 1. **Milestone Check**: If the issue already has a milestone assigned, the action will not reassign it
-2. **Issue Type Filtering**: If `issue-type` is provided, the action checks if the issue's GitHub issue type matches (case-insensitive)  
-3. **Label Filtering**: If `issue-label` is provided, the action checks if any issue label matches the specified filter (case-insensitive)
-4. **Milestone Matching**: The action finds the target milestone by name (case-insensitive)
+2. **Issue Type Filtering**: If `issue-type` is set, the issue's type must match (case-insensitive). Issues with no type (non-org repos) are skipped, not failed.
+3. **Label Filtering**: If `issue-label` is set, the issue must carry a label equal to the filter (exact match, case-insensitive)
+4. **Milestone Matching**: `target-milestone` is resolved against the repo's existing milestones by name (case-insensitive); the canonical title is used
 5. **Assignment**: Only assigns the milestone if all conditions are met
 
 ## Permissions
@@ -136,7 +181,12 @@ The GitHub token needs the following permissions:
 ## Reference Implementation
 
 This repository includes a working example of the action in [`.github/workflows/auto-milestone-wishlist.yaml`](.github/workflows/auto-milestone-wishlist.yaml).
-This workflow automatically assigns issues labeled with "enhancement" to a "Wishlist" milestone, demonstrating real-world usage of the `issue-label` filtering feature.
+This workflow automatically assigns issues labeled "enhancement" to a "Wishlist" milestone, demonstrating real-world usage of the `issue-label` filtering feature.
+
+Note how it layers a workflow-level `if:` (an efficiency gate that avoids spinning up a
+runner for non-enhancement issues) with the action's own `issue-label` filter (which
+enforces the label for `workflow_dispatch` runs). For a simple single-repo setup you'd
+typically pick just one — see [Do you even need this?](#do-you-even-need-this) above.
 
 You can use this as a template for creating your own milestone automation workflows.
 

--- a/assign-milestone.sh
+++ b/assign-milestone.sh
@@ -4,38 +4,74 @@
 # Assigns GitHub issues to milestones based on criteria
 
 set -e
-shopt -s inherit_errexit  # Ensure set -e applies in command substitutions
+# Ensure set -e applies in command substitutions. Best-effort: this option only
+# exists in bash 4+. GitHub runners are always bash 4+, so the hardening is active
+# in production; the guard just lets the script run on older local shells too.
+shopt -s inherit_errexit 2>/dev/null || true
 
 # Constants
 readonly MIN_ISSUE_NUMBER=1
 readonly MAX_ISSUE_NUMBER=999999999  # GitHub's practical limit
 readonly MAX_RETRY_ATTEMPTS=3
-readonly INITIAL_RETRY_DELAY=2
+# Overridable via env so tests can disable backoff sleeps; defaults to 2s.
+readonly INITIAL_RETRY_DELAY="${INITIAL_RETRY_DELAY:-2}"
 
 # Helper Functions
 # ================
 
-# Convert string to lowercase
+# Convert string to lowercase. Uses printf, not echo: echo would swallow values
+# that look like flags (e.g. a label or milestone literally named "-n" or "-e").
 to_lowercase() {
-  echo "$1" | tr '[:upper:]' '[:lower:]'
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
 
-# Retry a command with exponential backoff
+# Retry a command with exponential backoff.
+# The command's stdout passes through to the caller; its stderr is captured so we
+# can (a) avoid corrupting captured stdout and (b) decide whether to retry.
+# Only deterministic client errors fail fast - errors that can never succeed on
+# retry (400/401/404/410/422). Crucially, 403 and 429 are NOT in that set:
+# GitHub signals secondary/abuse rate limits with HTTP 403 (and sometimes 429),
+# which are transient and must be retried with backoff. Network errors (no HTTP
+# status in the output) are also retried.
 retry_gh_command() {
   local max_attempts=${MAX_RETRY_ATTEMPTS}
   local attempt=1
   local delay=${INITIAL_RETRY_DELAY}
+  local err_file
+  err_file=$(mktemp "${RUNNER_TEMP:-/tmp}/gh_stderr_XXXXXX")
 
   while (( attempt <= max_attempts )); do
-    if "$@"; then
+    if "$@" 2>"${err_file}"; then
+      rm -f "${err_file}"
       return 0
     fi
-    echo "::warning::Attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s..."
-    sleep "${delay}"
+
+    # Surface the underlying error for diagnostics.
+    cat "${err_file}" >&2
+
+    # Fail fast only on deterministic client errors. Parse the HTTP status once;
+    # if gh reported one of these, retrying cannot help.
+    local http_status
+    # shellcheck disable=SC2312  # grep exit status is intentionally ignored here
+    http_status=$(grep -oiE 'HTTP [0-9]{3}' "${err_file}" | grep -oE '[0-9]{3}' | head -1)
+    case "${http_status}" in
+      400|401|404|410|422)
+        echo "::warning::Non-retryable HTTP ${http_status}; not retrying." >&2
+        rm -f "${err_file}"
+        return 1
+        ;;
+      *) ;;  # any other status (incl. 403/429 rate limits, 5xx, none) → retry
+    esac
+
+    if (( attempt < max_attempts )); then
+      echo "::warning::Attempt ${attempt}/${max_attempts} failed, retrying in ${delay}s..." >&2
+      sleep "${delay}"
+    fi
     attempt=$((attempt + 1))
     delay=$((delay * 2))
   done
 
+  rm -f "${err_file}"
   return 1
 }
 
@@ -74,12 +110,8 @@ validate_inputs() {
     exit 1
   fi
 
-  # Validate milestone name
-  if [[ -z "${TARGET_MILESTONE}" ]]; then
-    set_output "reason" "Target milestone is required"
-    echo "::error::Target milestone is required"
-    exit 1
-  fi
+  # Note: TARGET_MILESTONE presence is already enforced by the ${VAR:?} guard
+  # above (it triggers on unset *or* empty), so no explicit -z check is needed.
 
   # Validate repository format
   if [[ ! "${REPOSITORY}" =~ ^[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+$ ]]; then
@@ -102,12 +134,16 @@ validate_inputs() {
 fetch_issue_data() {
   echo "::group::Fetching issue details" >&2
 
-  local issue_data
-  local temp_file="/tmp/gh_issue_data_$$"
+  local issue_data temp_file
+  # mktemp (not a predictable PID-based name) avoids symlink/stale-file races
+  # under a shared /tmp, matching retry_gh_command's stderr temp handling.
+  temp_file=$(mktemp "${RUNNER_TEMP:-/tmp}/gh_issue_data_XXXXXX")
 
-  # Fetch issue data using gh api (which supports all fields including type)
+  # Fetch issue data using gh api (which supports all fields including type).
+  # retry_gh_command captures the command's stderr separately, so temp_file
+  # holds only the JSON response - no stderr chatter to corrupt jq parsing.
   # shellcheck disable=SC2310  # Intentionally using in if condition
-  if retry_gh_command gh api "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}" > "${temp_file}" 2>&1; then
+  if retry_gh_command gh api "repos/${REPOSITORY}/issues/${ISSUE_NUMBER}" > "${temp_file}"; then
     # Extract only the fields we need from the full API response
     issue_data=$(jq '{milestone, labels, title, state, type}' < "${temp_file}" 2>/dev/null)
     rm -f "${temp_file}"
@@ -119,7 +155,7 @@ fetch_issue_data() {
     fi
   else
     rm -f "${temp_file}"
-    echo "::error::Failed to fetch issue data after ${MAX_RETRY_ATTEMPTS} attempts" >&2
+    echo "::error::Failed to fetch data for issue #${ISSUE_NUMBER} in ${REPOSITORY}" >&2
     exit 1
   fi
 
@@ -136,8 +172,10 @@ fetch_issue_data() {
   echo "::notice::Issue #${ISSUE_NUMBER}" >&2
   echo "::notice::Issue state: ${issue_state}" >&2
 
-  # Debug: Check if type field exists in the fetched data
-  if jq -e 'has("type")' <<< "${issue_data}" >/dev/null 2>&1; then
+  # Debug: report the issue type. Test `.type != null` (not has("type")): the
+  # field projection above always includes a "type" key, null for repos without
+  # issue types, so has("type") is always true. This mirrors apply_type_filter.
+  if jq -e '.type != null' <<< "${issue_data}" >/dev/null 2>&1; then
     local type_info
     type_info=$(jq -r '.type | if type == "object" then .name else . end' <<< "${issue_data}" 2>/dev/null || echo "unknown")
     echo "::debug::Issue type field detected in API response: ${type_info}" >&2
@@ -177,18 +215,22 @@ apply_type_filter() {
   echo "::group::Checking GitHub issue type filter"
 
   local issue_type_field=""
-  # Check if type field exists first, then extract appropriately
-  # Use jq directly with variable to avoid shell expansion issues
-  if jq -e 'has("type")' <<< "${issue_data}" >/dev/null 2>&1; then
+  # Extract the type only when it is actually present (non-null). The upstream
+  # field extraction always includes a "type" key (null for repos without issue
+  # types), and `jq -r` renders null as the string "null" - so we must test for
+  # a non-null value, not merely has("type"), to detect a genuinely typeless issue.
+  if jq -e '.type != null' <<< "${issue_data}" >/dev/null 2>&1; then
     # Extract the type name if type is an object, or the type itself if it's a string
     issue_type_field=$(jq -r 'if (.type | type) == "object" then .type.name else .type end' <<< "${issue_data}" 2>/dev/null || echo "")
   fi
 
-  # If type filter is specified but issue has no type field, error out
+  # If type filter is specified but issue has no type field, skip gracefully.
+  # This is a filter miss, not an error - issue types are only available for
+  # organization repositories with issue types configured.
   if [[ -z "${issue_type_field}" ]]; then
     local reason="Issue type filter \"${ISSUE_TYPE}\" specified but issue has no type field. Issue types are only available for organization repositories with issue types configured."
     set_output "reason" "${reason}"
-    echo "::error::${reason}"
+    echo "::notice::${reason}"
     echo "::endgroup::"
     return 1  # Signal to exit main
   fi
@@ -237,10 +279,10 @@ apply_label_filter() {
 
   local label_matches=false
   while IFS= read -r label; do
+    [[ -z "${label}" ]] && continue
     local label_lower
     label_lower=$(to_lowercase "${label}")
-    if [[ "${label_lower}" == *"${issue_label_lower}"* ]] || \
-       [[ "${issue_label_lower}" == *"${label_lower}"* ]]; then
+    if [[ "${label_lower}" == "${issue_label_lower}" ]]; then
       label_matches=true
       break
     fi
@@ -262,20 +304,71 @@ apply_label_filter() {
   return 0
 }
 
+# Resolve the target milestone to its canonical title (case-insensitive).
+# Echoes the real milestone title on success (return 0).
+# Return 1 = milestone does not exist; return 2 = the milestones fetch failed.
+# The caller must distinguish these so a transient/permission error is not
+# reported to the user as a missing milestone.
+resolve_milestone_title() {
+  local milestones resolved
+
+  # Fetch OPEN milestones only - a closed milestone is not a valid assignment
+  # target, so it must not be resolvable. Paginated for repos with many.
+  # stdout (the JSON) is captured here; retry_gh_command routes any error
+  # output to stderr so it surfaces in the action log without polluting it.
+  # shellcheck disable=SC2310  # Intentionally using in if condition
+  if ! milestones=$(retry_gh_command gh api --paginate \
+        "repos/${REPOSITORY}/milestones?state=open"); then
+    echo "::error::Failed to fetch milestones for ${REPOSITORY}" >&2
+    return 2
+  fi
+
+  # Fold BOTH the target and each title with ascii_downcase so the comparison
+  # uses one consistent casing rule. (Doing the target side with shell `tr` and
+  # the title side with jq diverges on non-ASCII names - e.g. tr lowercases "Ü"
+  # but ascii_downcase does not - which would fail to match a real milestone.)
+  # --paginate concatenates JSON arrays; -s slurps them into one stream.
+  resolved=$(jq -rs --arg t "${TARGET_MILESTONE}" \
+    'add // [] | map(select((.title | ascii_downcase) == ($t | ascii_downcase))) | .[0].title // empty' \
+    <<< "${milestones}" 2>/dev/null)
+
+  [[ -z "${resolved}" ]] && return 1
+  echo "${resolved}"
+}
+
 # Assign the issue to the target milestone
 assign_milestone() {
   echo "::group::Assigning milestone"
 
-  if gh issue edit "${ISSUE_NUMBER}" --repo "${REPOSITORY}" --milestone "${TARGET_MILESTONE}" 2>/dev/null; then
-    local reason="Successfully assigned issue to milestone: ${TARGET_MILESTONE}"
+  # Capture the resolver's exit code without tripping set -e (|| handler), so we
+  # can tell "milestone missing" (rc 1) from "couldn't fetch milestones" (rc 2).
+  local milestone_title resolve_rc=0
+  # shellcheck disable=SC2310  # || is intentional: we capture rc, not exit here
+  milestone_title=$(resolve_milestone_title) || resolve_rc=$?
+  if (( resolve_rc != 0 )); then
+    local reason
+    if (( resolve_rc == 2 )); then
+      reason="Could not fetch milestones for ${REPOSITORY} (check token permissions or API availability)"
+    else
+      reason="Milestone '${TARGET_MILESTONE}' not found in ${REPOSITORY}"
+    fi
+    set_output "reason" "${reason}"
+    echo "::error::${reason}"
+    echo "::endgroup::"
+    exit 1
+  fi
+
+  if gh issue edit "${ISSUE_NUMBER}" --repo "${REPOSITORY}" --milestone "${milestone_title}" 2>/dev/null; then
+    local reason="Successfully assigned issue to milestone: ${milestone_title}"
     set_output "assigned" "true"
-    set_output "milestone" "${TARGET_MILESTONE}"
+    set_output "milestone" "${milestone_title}"
     set_output "reason" "${reason}"
     echo "::notice::${reason}"
   else
-    local reason="Milestone '${TARGET_MILESTONE}' not found or assignment failed"
+    local reason="Failed to assign issue to milestone: ${milestone_title}"
     set_output "reason" "${reason}"
     echo "::error::${reason}"
+    echo "::endgroup::"
     exit 1
   fi
 
@@ -303,4 +396,7 @@ main() {
   assign_milestone
 }
 
-main "$@"
+# Only run main when executed directly, not when sourced (e.g. by the test suite).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/bin/gh
+++ b/tests/bin/gh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Minimal `gh` stub for offline end-to-end tests.
+# Responds from fixture files pointed to by env vars so the real
+# assign-milestone.sh can run without network or auth.
+#
+#   GH_MOCK_ISSUE       file with the JSON for `gh api repos/.../issues/N`
+#   GH_MOCK_MILESTONES  file with the JSON array for the milestones endpoint
+#   GH_MOCK_EDIT_RC     exit code for `gh issue edit` (default 0)
+#
+# To exercise the retry / fail-fast logic, `gh api` calls can be made to fail:
+#   GH_MOCK_API_RC      exit code for `gh api` calls (default 0 = success)
+#   GH_MOCK_API_STDERR  text emitted to stderr on `gh api` (e.g. an HTTP status)
+#   GH_MOCK_CALL_LOG    if set, one line is appended per `gh api` call (for
+#                       counting attempts: fail-fast = 1, full retry = N)
+
+set -euo pipefail
+
+args="$*"
+
+# Shared handling for `gh api` calls: record the attempt, emit canned stderr,
+# and fail with the requested exit code so retry/fail-fast paths are reachable.
+api_pre() {
+  if [[ -n "${GH_MOCK_CALL_LOG:-}" ]]; then echo "api" >> "${GH_MOCK_CALL_LOG}"; fi
+  if [[ -n "${GH_MOCK_API_STDERR:-}" ]]; then printf '%s\n' "${GH_MOCK_API_STDERR}" >&2; fi
+  if [[ "${GH_MOCK_API_RC:-0}" -ne 0 ]]; then exit "${GH_MOCK_API_RC}"; fi
+}
+
+case "${args}" in
+  *"/milestones"*)
+    api_pre
+    cat "${GH_MOCK_MILESTONES:-/dev/null}"
+    ;;
+  *"api "*"issues/"*)
+    api_pre
+    cat "${GH_MOCK_ISSUE:-/dev/null}"
+    ;;
+  "issue edit"*)
+    exit "${GH_MOCK_EDIT_RC:-0}"
+    ;;
+  *)
+    echo "gh stub: unhandled invocation: gh ${args}" >&2
+    exit 1
+    ;;
+esac

--- a/tests/fixtures/issue-has-milestone.json
+++ b/tests/fixtures/issue-has-milestone.json
@@ -1,0 +1,8 @@
+{
+  "number": 8,
+  "title": "Already planned",
+  "state": "open",
+  "milestone": { "title": "Backlog" },
+  "labels": [],
+  "type": null
+}

--- a/tests/fixtures/issue-open-no-milestone.json
+++ b/tests/fixtures/issue-open-no-milestone.json
@@ -1,0 +1,8 @@
+{
+  "number": 7,
+  "title": "Add dark mode",
+  "state": "open",
+  "milestone": null,
+  "labels": [{ "name": "enhancement" }, { "name": "build" }],
+  "type": null
+}

--- a/tests/fixtures/issue-typed-bug.json
+++ b/tests/fixtures/issue-typed-bug.json
@@ -1,0 +1,8 @@
+{
+  "number": 9,
+  "title": "Crash on save",
+  "state": "open",
+  "milestone": null,
+  "labels": [],
+  "type": { "name": "Bug" }
+}

--- a/tests/fixtures/milestones.json
+++ b/tests/fixtures/milestones.json
@@ -1,0 +1,5 @@
+[
+  { "title": "Backlog", "state": "open" },
+  { "title": "Wishlist", "state": "open" },
+  { "title": "Sprint 1", "state": "closed" }
+]

--- a/tests/test-composite.sh
+++ b/tests/test-composite.sh
@@ -1,235 +1,240 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# End-to-end test suite for Issue Milestoner.
+#
+# Unlike a unit suite that re-implements the logic, this runs the REAL
+# assign-milestone.sh as a subprocess with a mocked `gh` on PATH (see
+# tests/bin/gh) and fixture API responses (see tests/fixtures). It asserts on
+# the script's exit code, its GITHUB_OUTPUT contract, and its log annotations -
+# so the behavior under test is exactly what ships.
 
-# Automated Unit Test Suite for Issue Milestoner
-# Validates input handling and core logic without external dependencies
+set -uo pipefail
 
-set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+MOCK_BIN="${SCRIPT_DIR}/bin"
+ACTION="${REPO_ROOT}/assign-milestone.sh"
 
-echo "🧪 Automated Unit Test Suite"
-echo "============================"
-echo "🎯 Testing input validation and core logic"
-echo "🤖 Running $(basename "$0") in CI/automated mode"
-echo ""
-
-# Test framework setup
 TESTS_PASSED=0
 TESTS_FAILED=0
-TEST_OUTPUT_DIR="/tmp/issue-milestoner-tests"
-mkdir -p "$TEST_OUTPUT_DIR"
 
-# Unit test helper functions
-pass_test() {
-    local test_name="$1"
-    echo "  ✅ PASS: $test_name"
-    TESTS_PASSED=$((TESTS_PASSED + 1))
-}
+OUTPUT_FILE=""
+ACTION_LOG=""
+CALL_LOG=""
+ACTION_RC=0
 
-fail_test() {
-    local test_name="$1" 
-    local reason="$2"
-    echo "  ❌ FAIL: $test_name - $reason"
-    TESTS_FAILED=$((TESTS_FAILED + 1))
-}
-
-# Test function definitions
-test_issue_number_validation() {
-    echo "📝 Test Suite 1: Input Validation"
-    echo "  → Testing issue number validation..."
-    
-    # Test valid issue numbers
-    local valid_numbers=("1" "123" "9999")
-    for num in "${valid_numbers[@]}"; do
-        if [[ "$num" =~ ^[0-9]+$ ]] && [[ "$num" -gt 0 ]]; then
-            pass_test "Valid issue number: $num"
-        else
-            fail_test "Valid issue number: $num" "Should be valid"
-        fi
-    done
-    
-    # Test invalid issue numbers  
-    local invalid_numbers=("0" "-1" "abc" "1.5" "" " ")
-    for num in "${invalid_numbers[@]}"; do
-        if [[ ! "$num" =~ ^[0-9]+$ ]] || [[ "$num" -lt 1 ]]; then
-            pass_test "Invalid issue number: '$num'"
-        else
-            fail_test "Invalid issue number: '$num'" "Should be invalid"
-        fi
-    done
-}
-
-test_environment_validation() {
-    echo "  → Testing environment variable validation..."
-    
-    # Test required variables
-    local required_vars=("ISSUE_NUMBER" "TARGET_MILESTONE" "REPOSITORY")
-    for var in "${required_vars[@]}"; do
-        # Simulate empty variable
-        local value=""
-        if [[ -z "$value" ]]; then
-            pass_test "Required variable '$var' validation"
-        else
-            fail_test "Required variable '$var' validation" "Should detect empty value"
-        fi
-    done
-    
-    # Test optional variables
-    local optional_vars=("ISSUE_TYPE" "ISSUE_LABEL") 
-    for var in "${optional_vars[@]}"; do
-        # Simulate empty optional variable (should be allowed)
-        local value=""
-        if [[ -z "$value" ]]; then
-            pass_test "Optional variable '$var' validation" 
-        fi
-    done
-}
-
-test_filtering_logic() {
-    echo "📝 Test Suite 2: Issue Type and Label Filtering"
-    echo "  → Testing issue type matching logic..."
-    
-    # Test issue type matching (exact match, case-insensitive)
-    test_issue_type_filter() {
-        local issue_type="$1"
-        local filter_type="$2"
-        
-        local issue_type_lower filter_type_lower
-        issue_type_lower=$(echo "$issue_type" | tr '[:upper:]' '[:lower:]')
-        filter_type_lower=$(echo "$filter_type" | tr '[:upper:]' '[:lower:]')
-        
-        [[ "$issue_type_lower" == "$filter_type_lower" ]]
-    }
-    
-    # Test issue type cases
-    local issue_type_cases=(
-        "bug|bug|true"
-        "Bug|bug|true"  
-        "FEATURE|feature|true"
-        "task|bug|false"
-    )
-    
-    for case in "${issue_type_cases[@]}"; do
-        IFS='|' read -r issue_type filter_type expected <<< "$case"
-        
-        if test_issue_type_filter "$issue_type" "$filter_type"; then
-            result="true"
-        else
-            result="false"
-        fi
-        
-        if [[ "$result" == "$expected" ]]; then
-            pass_test "Issue type match: '$filter_type' vs '$issue_type'"
-        else
-            fail_test "Issue type match: '$filter_type' vs '$issue_type'" "Expected $expected, got $result"
-        fi
-    done
-    
-    echo "  → Testing label matching logic..."
-    
-    # Simulate label filtering logic from assign-milestone.sh
-    test_label_filter() {
-        local labels="$1"
-        local issue_label="$2"
-        local issue_label_lower
-        issue_label_lower=$(echo "$issue_label" | tr '[:upper:]' '[:lower:]')
-        
-        local label_matches=false
-        while IFS= read -r label; do
-            [[ -z "$label" ]] && continue
-            # Convert label to lowercase for case-insensitive comparison
-            local label_lower
-            label_lower=$(echo "$label" | tr '[:upper:]' '[:lower:]')
-            if [[ "$label_lower" == *"$issue_label_lower"* ]] || [[ "$issue_label_lower" == *"$label_lower"* ]]; then
-                label_matches=true
-                break
-            fi
-        done <<< "$labels"
-        
-        [[ "$label_matches" == "true" ]]
-    }
-    
-    # Test cases for label matching  
-    local label_test_cases=(
-        "bug,enhancement,docs|bug|true"
-        "enhancement,feature|bug|false" 
-        "BUG,Enhancement|Bug|true"
-        "ui,ux,design|ui|true"
-        "backend,api|frontend|false"
-    )
-    
-    for case in "${label_test_cases[@]}"; do
-        IFS='|' read -r labels issue_label expected <<< "$case"
-        labels=$(echo "$labels" | tr ',' '\n')
-        
-        if test_label_filter "$labels" "$issue_label"; then
-            result="true"
-        else
-            result="false"
-        fi
-        
-        if [[ "$result" == "$expected" ]]; then
-            pass_test "Label match: '$issue_label' in labels"
-        else
-            fail_test "Label match: '$issue_label' in labels" "Expected $expected, got $result"
-        fi
-    done
-}
-
-test_output_format() {
-    echo "📝 Test Suite 3: Output Format"
-    echo "  → Testing GitHub Actions output format..."
-    
-    # Test valid output formats
-    local test_outputs=(
-        "assigned=true"
-        "reason=Milestone assigned successfully" 
-        "milestone=v1.0.0"
-        "issue_number=123"
-    )
-    
-    local output_file="$TEST_OUTPUT_DIR/test_output"
-    for output in "${test_outputs[@]}"; do
-        echo "$output" > "$output_file"
-        
-        # Validate format: key=value
-        if grep -q '^[a-zA-Z_][a-zA-Z0-9_]*=.*$' "$output_file"; then
-            pass_test "Output format: '$output'"
-        else  
-            fail_test "Output format: '$output'" "Invalid key=value format"
-        fi
-    done
-    
-    rm -f "$output_file"
-}
-
-# Execute all unit tests
-echo "🚀 Executing Unit Tests..."
-echo "========================="
-
-test_issue_number_validation
-echo ""
-test_environment_validation  
-echo ""
-test_filtering_logic
-echo ""
-test_output_format
+echo "🧪 Issue Milestoner — end-to-end suite"
+echo "======================================"
 echo ""
 
-# Test summary
-echo "📊 Test Results Summary"
-echo "======================"
-echo "✅ Passed: $TESTS_PASSED"
-echo "❌ Failed: $TESTS_FAILED" 
-echo "📈 Total:  $((TESTS_PASSED + TESTS_FAILED))"
+# --- helpers ----------------------------------------------------------------
 
-if [[ $TESTS_FAILED -eq 0 ]]; then
-    echo ""
-    echo "🎉 All unit tests passed!"
-    exit 0
-else
-    echo ""
-    echo "💥 Some unit tests failed!"
-    exit 1
-fi
+pass() { echo "  ✅ PASS: $1"; TESTS_PASSED=$((TESTS_PASSED + 1)); }
+fail() { echo "  ❌ FAIL: $1 — $2"; TESTS_FAILED=$((TESTS_FAILED + 1)); }
 
-# Cleanup
-rm -rf "$TEST_OUTPUT_DIR"
+# Run the real action with the given inputs. Inputs are passed as env vars by
+# the caller; defaults are filled here. The mocked gh serves fixtures named by
+# GH_MOCK_ISSUE / GH_MOCK_MILESTONES.
+run_action() {
+  OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/im_out_XXXXXX")"
+  ACTION_LOG="$(mktemp "${TMPDIR:-/tmp}/im_log_XXXXXX")"
+  CALL_LOG="$(mktemp "${TMPDIR:-/tmp}/im_calls_XXXXXX")"
+
+  PATH="${MOCK_BIN}:${PATH}" \
+  GH_TOKEN="test-token" \
+  GITHUB_OUTPUT="${OUTPUT_FILE}" \
+  INITIAL_RETRY_DELAY=0 \
+  ISSUE_NUMBER="${ISSUE_NUMBER:-7}" \
+  REPOSITORY="${REPOSITORY:-acme/widgets}" \
+  TARGET_MILESTONE="${TARGET_MILESTONE:-Wishlist}" \
+  ISSUE_TYPE="${ISSUE_TYPE:-}" \
+  ISSUE_LABEL="${ISSUE_LABEL:-}" \
+  GH_MOCK_ISSUE="${GH_MOCK_ISSUE:-}" \
+  GH_MOCK_MILESTONES="${GH_MOCK_MILESTONES:-${FIXTURES}/milestones.json}" \
+  GH_MOCK_EDIT_RC="${GH_MOCK_EDIT_RC:-0}" \
+  GH_MOCK_API_RC="${GH_MOCK_API_RC:-0}" \
+  GH_MOCK_API_STDERR="${GH_MOCK_API_STDERR:-}" \
+  GH_MOCK_CALL_LOG="${CALL_LOG}" \
+    bash "${ACTION}" >"${ACTION_LOG}" 2>&1
+  ACTION_RC=$?
+}
+
+# Last value wins, matching GitHub Actions output semantics.
+get_output() { grep "^$1=" "${OUTPUT_FILE}" | tail -n1 | cut -d= -f2-; }
+
+assert_rc() {
+  local want="$1" name="$2"
+  if [[ "${ACTION_RC}" -eq "${want}" ]]; then pass "${name} (exit ${want})"
+  else fail "${name}" "expected exit ${want}, got ${ACTION_RC}; log: $(<"${ACTION_LOG}")"; fi
+}
+
+assert_output() {
+  local key="$1" want="$2" name="$3" got
+  got="$(get_output "${key}")"
+  if [[ "${got}" == "${want}" ]]; then pass "${name} (${key}=${want})"
+  else fail "${name}" "expected ${key}='${want}', got '${got}'"; fi
+}
+
+assert_log_contains() {
+  if grep -qF "$1" "${ACTION_LOG}"; then pass "$2"
+  else fail "$2" "log missing: $1"; fi
+}
+
+assert_log_excludes() {
+  if grep -qF "$1" "${ACTION_LOG}"; then fail "$2" "log unexpectedly contains: $1"
+  else pass "$2"; fi
+}
+
+assert_call_count() {
+  local want="$1" name="$2" got
+  got=$(wc -l < "${CALL_LOG}" | tr -d '[:space:]')
+  if [[ "${got}" -eq "${want}" ]]; then pass "${name} (${want} gh api call(s))"
+  else fail "${name}" "expected ${want} gh api call(s), got ${got}"; fi
+}
+
+cleanup_case() { rm -f "${OUTPUT_FILE}" "${ACTION_LOG}" "${CALL_LOG}"; }
+
+# --- tests ------------------------------------------------------------------
+
+test_label_exact_rejects_nearmiss() {
+  echo "📝 Label filter is exact (regression: substring matching)"
+  ISSUE_LABEL="ui" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" \
+    run_action  # labels are enhancement, build — neither equals "ui"
+  assert_rc 0 "near-miss label does not assign"
+  assert_output assigned false "near-miss label leaves issue unassigned"
+  cleanup_case
+}
+
+test_label_exact_matches() {
+  echo "📝 Label filter matches an exact label"
+  ISSUE_LABEL="enhancement" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" \
+    run_action
+  assert_rc 0 "exact label assigns"
+  assert_output assigned true "exact label assigns"
+  cleanup_case
+}
+
+test_milestone_case_insensitive() {
+  echo "📝 Target milestone resolves case-insensitively to canonical title"
+  TARGET_MILESTONE="wishlist" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" \
+    run_action  # no filters → assigns
+  assert_rc 0 "lowercase target assigns"
+  assert_output assigned true "lowercase target assigns"
+  assert_output milestone "Wishlist" "output reports canonical milestone casing"
+  cleanup_case
+}
+
+test_milestone_not_found() {
+  echo "📝 Unknown milestone fails clearly"
+  TARGET_MILESTONE="Ghost" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" \
+    run_action
+  assert_rc 1 "unknown milestone exits non-zero"
+  assert_output assigned false "unknown milestone leaves issue unassigned"
+  assert_log_contains "not found in acme/widgets" "unknown milestone is reported"
+  cleanup_case
+}
+
+test_already_assigned() {
+  echo "📝 Existing milestone is never overwritten"
+  GH_MOCK_ISSUE="${FIXTURES}/issue-has-milestone.json" run_action
+  assert_rc 0 "already-assigned exits cleanly"
+  assert_output assigned false "already-assigned does not reassign"
+  assert_output milestone "Backlog" "already-assigned reports current milestone"
+  cleanup_case
+}
+
+test_type_filter_no_field_is_notice() {
+  echo "📝 Type filter on a typeless issue is a notice, not an error"
+  ISSUE_TYPE="bug" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 0 "typeless + type filter exits cleanly"
+  assert_output assigned false "typeless + type filter does not assign"
+  assert_log_contains "::notice::Issue type filter" "typeless type filter logs a notice"
+  assert_log_excludes "::error::Issue type filter" "typeless type filter is not an error"
+  cleanup_case
+}
+
+test_type_filter_match() {
+  echo "📝 Type filter matches the issue's type (case-insensitive)"
+  ISSUE_TYPE="bug" GH_MOCK_ISSUE="${FIXTURES}/issue-typed-bug.json" run_action
+  assert_rc 0 "matching type assigns"
+  assert_output assigned true "matching type assigns"
+  cleanup_case
+}
+
+test_type_filter_mismatch() {
+  echo "📝 Type filter that does not match skips assignment"
+  ISSUE_TYPE="feature" GH_MOCK_ISSUE="${FIXTURES}/issue-typed-bug.json" run_action
+  assert_rc 0 "mismatched type exits cleanly"
+  assert_output assigned false "mismatched type does not assign"
+  cleanup_case
+}
+
+# --- input validation (validate_inputs) -------------------------------------
+
+test_invalid_issue_number() {
+  echo "📝 Non-numeric issue number is rejected"
+  ISSUE_NUMBER="abc" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 1 "non-numeric issue number fails"
+  assert_output assigned false "invalid issue number does not assign"
+  assert_log_contains "Invalid issue number" "invalid issue number is reported"
+  assert_call_count 0 "invalid issue number never calls the API"
+  cleanup_case
+}
+
+test_invalid_repository() {
+  echo "📝 Malformed repository is rejected"
+  REPOSITORY="not-a-repo" GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 1 "malformed repository fails"
+  assert_log_contains "owner/repo" "malformed repository is reported"
+  cleanup_case
+}
+
+test_control_char_milestone() {
+  echo "📝 Control characters in the milestone name are rejected"
+  TARGET_MILESTONE=$'bad\x01name' GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 1 "control-char milestone fails"
+  assert_log_contains "control characters" "control-char milestone is reported"
+  cleanup_case
+}
+
+# --- retry / fail-fast classification (retry_gh_command) --------------------
+
+test_404_fails_fast() {
+  echo "📝 A deterministic HTTP 404 fails fast (no retry)"
+  GH_MOCK_API_RC=1 GH_MOCK_API_STDERR="gh: Not Found (HTTP 404)" \
+    GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 1 "404 aborts the run"
+  assert_call_count 1 "404 is not retried"
+  cleanup_case
+}
+
+test_403_rate_limit_is_retried() {
+  echo "📝 An HTTP 403 secondary rate limit is retried, not treated as fatal"
+  GH_MOCK_API_RC=1 \
+    GH_MOCK_API_STDERR="gh: HTTP 403: You have exceeded a secondary rate limit" \
+    GH_MOCK_ISSUE="${FIXTURES}/issue-open-no-milestone.json" run_action
+  assert_rc 1 "403 still ultimately fails after retries"
+  assert_call_count 3 "403 is retried up to MAX_RETRY_ATTEMPTS"
+  cleanup_case
+}
+
+# --- run --------------------------------------------------------------------
+
+test_label_exact_rejects_nearmiss; echo ""
+test_label_exact_matches; echo ""
+test_milestone_case_insensitive; echo ""
+test_milestone_not_found; echo ""
+test_already_assigned; echo ""
+test_type_filter_no_field_is_notice; echo ""
+test_type_filter_match; echo ""
+test_type_filter_mismatch; echo ""
+test_invalid_issue_number; echo ""
+test_invalid_repository; echo ""
+test_control_char_milestone; echo ""
+test_404_fails_fast; echo ""
+test_403_rate_limit_is_retried; echo ""
+
+echo "📊 Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+[[ "${TESTS_FAILED}" -eq 0 ]] && { echo "🎉 All tests passed!"; exit 0; }
+echo "💥 Some tests failed!"; exit 1


### PR DESCRIPTION
Milestone/label correctness fixes plus a rewritten offline test suite. This is a **major release (v2.0.0)** — see the breaking changes below.

> **Merge note:** squash-merge with this PR title as the subject, and keep both `BREAKING CHANGE:` footers in the squash commit body so release-please records them and bumps to `2.0.0`.

## `assign-milestone.sh`
- `issue-label` now matches the **exact** label (case-insensitive), not a substring
- `target-milestone` resolves case-insensitively against **open** milestones using the canonical title; both sides folded with jq `ascii_downcase` (fixes non-ASCII names)
- distinguish "milestone not found" from "failed to fetch milestones"
- retry only deterministic 4xx (400/401/404/410/422); 403/429 rate limits and 5xx retry with backoff; stderr captured separately from the JSON payload
- `to_lowercase` uses `printf` so flag-like values (`-n`/`-e`) aren't swallowed
- detect typeless issues via `.type != null` (field extraction always injects `type`)
- `mktemp` for the issue temp file; best-effort `inherit_errexit` for bash 3.2

## Tests
- `tests/test-composite.sh` rewritten as **end-to-end**: drives the real script via a mocked `gh` (`tests/bin/gh`) with fixtures; covers label/type/milestone behavior, input validation, and retry/fail-fast classification (33 assertions)

## Docs / CI
- README repositioned (lead with issue-type, "do you even need this?", migration notes)
- shellcheck extended to `tests/`; orphan markdownlint config removed

---

BREAKING CHANGE: `issue-label` now matches the exact label (case-insensitive), not a substring. Previously `issue-label: ui` matched a label like `build` and `bug` matched `debugging`, assigning milestones unexpectedly. Set `issue-label` to the exact label name; for partial matching across several labels, use one action step per label.

BREAKING CHANGE: `target-milestone` now resolves only against OPEN milestones. A closed milestone is no longer a valid assignment target (previously the name was passed straight to `gh`, which could assign closed milestones). Reopen the milestone or target an open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)